### PR TITLE
fix: component generator and quality of life file hierarchy sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![rocket science header image](https://i.imgur.com/f743o61.png)
+
 # 📝 Summary
 
 An opinionated UI Workbench featuring tools like react, styled components, typescript, webpack, jest and storybook all bundled into an easy to use interface

--- a/src/components/templates/MSWTemplates/apollo/App.stories.js
+++ b/src/components/templates/MSWTemplates/apollo/App.stories.js
@@ -4,7 +4,7 @@ import { graphql } from 'msw';
 import { App } from './App';
 
 export default {
-  title: 'Templates & Guides/MSW Demos/Apollo',
+  title: 'Templates & Guides/Application Examples/Apollo',
   component: App,
 };
 

--- a/src/components/templates/MSWTemplates/axios/App.stories.js
+++ b/src/components/templates/MSWTemplates/axios/App.stories.js
@@ -3,7 +3,7 @@ import { rest } from 'msw';
 import { App } from './App';
 
 export default {
-  title: 'Templates & Guides/MSW Demos/Axios',
+  title: 'Templates & Guides/Application Examples/Axios',
   component: App,
 };
 

--- a/src/components/templates/MSWTemplates/fetch/App.stories.js
+++ b/src/components/templates/MSWTemplates/fetch/App.stories.js
@@ -3,7 +3,7 @@ import { rest } from 'msw';
 import { App } from './App';
 
 export default {
-  title: 'Templates & Guides/MSW Demos/Fetch',
+  title: 'Templates & Guides/Application Examples/Fetch',
   component: App,
 };
 

--- a/src/components/templates/MSWTemplates/react-query/App.stories.js
+++ b/src/components/templates/MSWTemplates/react-query/App.stories.js
@@ -4,7 +4,7 @@ import { rest } from 'msw';
 import { App } from './App';
 
 export default {
-  title: 'Templates & Guides/MSW Demos/React Query',
+  title: 'Templates & Guides/Application Examples/React Query',
   component: App,
 };
 

--- a/src/components/templates/MSWTemplates/react-router-react-query/App.stories.js
+++ b/src/components/templates/MSWTemplates/react-router-react-query/App.stories.js
@@ -5,7 +5,7 @@ import { rest } from 'msw';
 import { App } from './App';
 
 export default {
-  title: 'Templates & Guides/MSW Demos/React Router + RQ',
+  title: 'Templates & Guides/Application Examples/React Router + RQ',
   component: App,
 };
 

--- a/src/components/templates/MSWTemplates/react-router-react-query/pages/character/Character.stories.js
+++ b/src/components/templates/MSWTemplates/react-router-react-query/pages/character/Character.stories.js
@@ -5,7 +5,7 @@ import { rest } from 'msw';
 import Character from './Character';
 
 export default {
-  title: 'Templates & Guides/MSW Demos/React Router + RQ/Page Stories/Character',
+  title: 'Templates & Guides/Application Examples/React Router + RQ/Page Stories/Character',
   component: Character,
 };
 

--- a/src/components/templates/MSWTemplates/react-router-react-query/pages/characters/Characters.stories.js
+++ b/src/components/templates/MSWTemplates/react-router-react-query/pages/characters/Characters.stories.js
@@ -5,7 +5,7 @@ import { rest } from 'msw';
 import Characters from './Characters';
 
 export default {
-  title: 'Templates & Guides/MSW Demos/React Router + RQ/Page Stories/Characters',
+  title: 'Templates & Guides/Application Examples/React Router + RQ/Page Stories/Characters',
   component: Characters,
 };
 

--- a/src/components/templates/MSWTemplates/react-router-react-query/pages/film/Film.stories.js
+++ b/src/components/templates/MSWTemplates/react-router-react-query/pages/film/Film.stories.js
@@ -5,7 +5,7 @@ import { rest } from 'msw';
 import Film from './Film';
 
 export default {
-  title: 'Templates & Guides/MSW Demos/React Router + RQ/Page Stories/Film',
+  title: 'Templates & Guides/Application Examples/React Router + RQ/Page Stories/Film',
   component: Film,
 };
 

--- a/src/components/templates/MSWTemplates/react-router-react-query/pages/films/Films.stories.js
+++ b/src/components/templates/MSWTemplates/react-router-react-query/pages/films/Films.stories.js
@@ -5,7 +5,7 @@ import { rest } from 'msw';
 import Films from './Films';
 
 export default {
-  title: 'Templates & Guides/MSW Demos/React Router + RQ/Page Stories/Films',
+  title: 'Templates & Guides/Application Examples/React Router + RQ/Page Stories/Films',
   component: Films,
 };
 

--- a/src/components/templates/MSWTemplates/urql/App.stories.js
+++ b/src/components/templates/MSWTemplates/urql/App.stories.js
@@ -4,7 +4,7 @@ import { graphql } from 'msw';
 import { App } from './App';
 
 export default {
-  title: 'Templates & Guides/MSW Demos/Urql',
+  title: 'Templates & Guides/Application Examples/Urql',
   component: App,
 };
 

--- a/src/components/templates/NewComponentTemplate/stories/NewComponentTemplateFed.stories.tsx
+++ b/src/components/templates/NewComponentTemplate/stories/NewComponentTemplateFed.stories.tsx
@@ -23,7 +23,7 @@ export default {
 //
 // 2. Uncomment the code below
 //
-// 3. Run $ yarn story
+// 3. Run $ yarn launch
 //
 // ==============================
 

--- a/src/util/cli/generateComponent/index.ts
+++ b/src/util/cli/generateComponent/index.ts
@@ -87,7 +87,7 @@ const makeDefaultStoryFile = name => {
   import ${name} from "../${name}";
   
   export default {
-    title: "${name}/Default",
+    title: "Newly Generated/${name}/Default",
     component: ${name},
     argTypes: {
       text: { control: "text" },
@@ -135,11 +135,11 @@ const makeDefaultStoryFile = name => {
 const makeFederatedStoryFile = name => {
   const storyFile = `import React from "react";
   import { ComponentStory, ComponentMeta } from "@storybook/react";
-  import DynamicRemoteContainer from "../../../../util/hooks/DynamicRemoteContainer";
+  import DynamicRemoteContainer from "../../../util/hooks/DynamicRemoteContainer";
   const Readme = require("../README.md").default;
   
   export default {
-    title: "${name}/Federated",
+    title: "Newly Generated/${name}/Federated",
     component: DynamicRemoteContainer,
   } as ComponentMeta<typeof DynamicRemoteContainer>;
   
@@ -287,8 +287,8 @@ inquirer
     {
       type: 'list',
       name: 'componentType',
-      choices: ['Federated Organism', 'Feature Level Component'],
-      message: 'Is this a federated organism or a feature level component?',
+      choices: ['Federated Feature', 'Atomic Level Component'],
+      message: 'Is this a Federated Feature or a Atomic Level Component?',
     },
   ])
   .then(answers => {
@@ -310,7 +310,7 @@ inquirer
     if (!fs.existsSync(storiesDir)) {
       fs.mkdirSync(storiesDir, {recursive: false})
       makeDefaultStoryFile(name)
-      if (componentType === 'Federated Organism') {
+      if (componentType === 'Federated Feature') {
         makeFederatedStoryFile(name)
       }
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,8 @@ module.exports = {
       filename: 'remoteEntry.js',
       remotes: {},
       exposes: {
-        './NewComponentTemplate': './src/components/NewComponentTemplate',
+        './NewComponentTemplate': './src/components/templates/NewComponentTemplate',
+        './NewHotness': './src/components/NewHotness'
       },
       shared: {
         ...deps,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,6 @@ module.exports = {
       remotes: {},
       exposes: {
         './NewComponentTemplate': './src/components/templates/NewComponentTemplate',
-        './NewHotness': './src/components/NewHotness'
       },
       shared: {
         ...deps,


### PR DESCRIPTION
component generator needed to update some file paths to account for changes over the last few commits - definitely worth settings up some tests for the inquirer flows in the future! 

## Changes

- restructured the default included stories into clearer namespacing
- newly generated components now sort into a "Newly Generated" story folder

