### PR TITLE
rs config file for port configuration

### DIFF
--- a/rs.config.js
+++ b/rs.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  federatedServerPort: "3001",
+};

--- a/src/components/templates/NewComponentTemplate/stories/NewComponentTemplateFed.stories.tsx
+++ b/src/components/templates/NewComponentTemplate/stories/NewComponentTemplateFed.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import DynamicRemoteContainer from "../../../../util/hooks/DynamicRemoteContainer";
 const Readme = require("../README.md").default;
+const { federatedServerPort } = require("../../../../../rs.config");
 
 export default {
   title: "Templates & Guides/NewComponentTemplate/Federated",
@@ -46,7 +47,7 @@ ModFedPrimary.args = {
   componentProps: {
     text: "Hello World",
   },
-  url: "http://localhost:3001/remoteEntry.js",
+  url: `http://localhost:${federatedServerPort}/remoteEntry.js`,
   scope: "RocketScience",
   module: "./NewComponentTemplate",
 };
@@ -61,7 +62,7 @@ ModFedSecondary.args = {
   componentProps: {
     text: "",
   },
-  url: "http://localhost:3001/remoteEntry.js",
+  url: `http://localhost:${federatedServerPort}/remoteEntry.js`,
   scope: "RocketScience",
   module: "./NewComponentTemplate",
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,14 @@
-const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin')
-
-const deps = require('./package.json').dependencies
+const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
+const { federatedServerPort } = require("./rs.config");
+const deps = require("./package.json").dependencies;
 
 module.exports = {
   resolve: {
-    extensions: ['.tsx', '.ts', '.jsx', '.js', '.json', '.md'],
+    extensions: [".tsx", ".ts", ".jsx", ".js", ".json", ".md"],
   },
 
   output: {
-    publicPath: 'http://localhost:3001/',
+    publicPath: `http://localhost:${federatedServerPort}/`,
   },
 
   devServer: {
@@ -19,20 +19,20 @@ module.exports = {
     rules: [
       {
         test: /\.m?js/,
-        type: 'javascript/auto',
+        type: "javascript/auto",
         resolve: {
           fullySpecified: false,
         },
       },
       {
         test: /\.css$/i,
-        use: ['style-loader', 'css-loader'],
+        use: ["style-loader", "css-loader"],
       },
       {
         test: /\.(ts|tsx|js|jsx)$/,
         exclude: /node_modules/,
         use: {
-          loader: 'babel-loader',
+          loader: "babel-loader",
         },
       },
     ],
@@ -40,11 +40,12 @@ module.exports = {
 
   plugins: [
     new ModuleFederationPlugin({
-      name: 'RocketScience',
-      filename: 'remoteEntry.js',
+      name: "RocketScience",
+      filename: "remoteEntry.js",
       remotes: {},
       exposes: {
-        './NewComponentTemplate': './src/components/templates/NewComponentTemplate',
+        "./NewComponentTemplate":
+          "./src/components/templates/NewComponentTemplate",
       },
       shared: {
         ...deps,
@@ -52,11 +53,11 @@ module.exports = {
           singleton: true,
           requiredVersion: deps.react,
         },
-        'react-dom': {
+        "react-dom": {
           singleton: true,
-          requiredVersion: deps['react-dom'],
+          requiredVersion: deps["react-dom"],
         },
       },
     }),
   ],
-}
+};


### PR DESCRIPTION
A global rocket-science specific config file with a port configuration to start that can be used globally throughout the project. We can add any global rocket-science app specific configuration values that we want.

## Changes

- rs.config.js file in the root directory
- reference the global port config for outputPath in webpack config and for the dynamic remote container URL

## API Updates

### New Features _(required)_

N/A

### Deprecations _(required)_

N/A

### Enhancements _(optional)_

Anywhere that the port for the server that is serving our /dist directory is referenced makes use of the value in
rs.config.js. This is also necessary for the create-rs-app cli so that users can specify which port they want to make use of for the federated server and be able to write a new port value to the config file rather than having to parse and write to all instances of where the port is referenced.

## Checklist

- [ ] Unit tests
- [ ] Documentation

## References

(optional)

Include **important** links regarding the implementation of this PR. This
usually includes and RFC or an aggregation of issues and/or individual
conversations that helped put this solution together. This helps ensure there is
a good aggregation of resources regarding the implementation.

Fixes #85, Fixes #22, Fixes username/repo#123 Connects #123
